### PR TITLE
made filter structs callable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ documentation = "https://matthiasbeyer.github.io/filters/filters/index.html"
 repository = "https://github.com/matthiasbeyer/filters"
 
 [dependencies]
+
+[features]
+unstable-filter-as-fn = []

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -30,7 +30,7 @@ impl<I, T: Fn(&I) -> bool> Filter<I> for T {
     }
 }
 
-/// The filter trai
+/// The filter trait
 pub trait Filter<N> {
 
     /// The function which is used to filter something

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "unstable-filter-as-fn", feature(unboxed_closures))]
+#![cfg_attr(feature = "unstable-filter-as-fn", feature(fn_traits))]
 //! A library for constructing predicates and filters for `Iterator::filter`
 //!
 //! This library offers types and traits for creating filters and combining them with logical
@@ -69,4 +71,3 @@
 
 pub mod filter;
 pub mod ops;
-

--- a/src/ops/and.rs
+++ b/src/ops/and.rs
@@ -20,10 +20,54 @@ impl<T, U> And<T, U> {
 
 }
 
+#[cfg(not(feature = "unstable-filter-as-fn"))]
 impl<I, T: Filter<I>, U: Filter<I>> Filter<I> for And<T, U> {
 
     fn filter(&self, e: &I) -> bool {
         self.a.filter(e) && self.b.filter(e)
     }
 
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, T, U, I> FnOnce<(&'a I,)> for And<T, U>
+    where T: Filter<I>,
+          U: Filter<I>,
+{
+    type Output = bool;
+    extern "rust-call" fn call_once(self, (arg,): (&'a I,)) -> Self::Output
+    {
+        (self)(arg)
+    }
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, T, U, I> FnMut<(&'a I,)> for And<T, U>
+    where T: Filter<I>,
+          U: Filter<I>,
+{
+    extern "rust-call" fn call_mut(&mut self, (arg,): (&'a I,)) -> Self::Output
+    {
+        (self)(arg)
+    }
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, T, U, I> Fn<(&'a I,)> for And<T, U>
+    where T: Filter<I>,
+          U: Filter<I>,
+{
+    extern "rust-call" fn call(&self, (arg,): (&'a I,)) -> Self::Output
+    {
+        self.a.filter(arg) && self.b.filter(arg)
+    }
+}
+
+#[cfg(feature="unstable-filter-as-fn")]
+#[test]
+fn fn_and() {
+    let and = And::new(|&x: &usize| x > 3, |&x: &usize| x < 7);
+    for i in 0..10 {
+        assert_eq!(and.filter(&i), and(&i))
+    }
 }

--- a/src/ops/and.rs
+++ b/src/ops/and.rs
@@ -35,7 +35,7 @@ impl<'a, T, U, I> FnOnce<(&'a I,)> for And<T, U>
           U: Filter<I>,
 {
     type Output = bool;
-    extern "rust-call" fn call_once(self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_once(self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -46,7 +46,7 @@ impl<'a, T, U, I> FnMut<(&'a I,)> for And<T, U>
     where T: Filter<I>,
           U: Filter<I>,
 {
-    extern "rust-call" fn call_mut(&mut self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_mut(&mut self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -57,7 +57,7 @@ impl<'a, T, U, I> Fn<(&'a I,)> for And<T, U>
     where T: Filter<I>,
           U: Filter<I>,
 {
-    extern "rust-call" fn call(&self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call(&self, (arg,): (&I,)) -> Self::Output
     {
         self.a.filter(arg) && self.b.filter(arg)
     }

--- a/src/ops/bool.rs
+++ b/src/ops/bool.rs
@@ -3,6 +3,7 @@
 //! Will be automatically included when incluing `filter::Filter`, so importing this module
 //! shouldn't be necessary.
 //!
+#[cfg(not(feature = "unstable-filter-as-fn"))]
 use filter::Filter;
 
 #[must_use = "filters are lazy and do nothing unless consumed"]
@@ -19,6 +20,7 @@ impl Bool {
 
 }
 
+#[cfg(not(feature = "unstable-filter-as-fn"))]
 impl<I> Filter<I> for Bool {
 
     fn filter(&self, _: &I) -> bool {
@@ -35,3 +37,36 @@ impl From<bool> for Bool {
 
 }
 
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, I> FnOnce<(&'a I,)> for Bool {
+    type Output = bool;
+    extern "rust-call" fn call_once(self, (arg,): (&'a I,)) -> Self::Output
+    {
+        (self)(arg)
+    }
+}
+
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, I> FnMut<(&'a I,)> for Bool {
+    extern "rust-call" fn call_mut(&mut self, (arg,): (&'a I,)) -> Self::Output
+    {
+        (self)(arg)
+    }
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, I> Fn<(&'a I,)> for Bool {
+    extern "rust-call" fn call(&self, (_,): (&'a I,)) -> Self::Output
+    {
+        self.b
+    }
+}
+
+#[cfg(feature="unstable-filter-as-fn")]
+#[test]
+fn fn_bool() {
+    use filter::Filter;
+    let b = Bool::new(true);
+    assert_eq!(b.filter(&3), b(&27));
+}

--- a/src/ops/bool.rs
+++ b/src/ops/bool.rs
@@ -40,7 +40,7 @@ impl From<bool> for Bool {
 #[cfg(feature = "unstable-filter-as-fn")]
 impl<'a, I> FnOnce<(&'a I,)> for Bool {
     type Output = bool;
-    extern "rust-call" fn call_once(self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_once(self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -49,7 +49,7 @@ impl<'a, I> FnOnce<(&'a I,)> for Bool {
 
 #[cfg(feature = "unstable-filter-as-fn")]
 impl<'a, I> FnMut<(&'a I,)> for Bool {
-    extern "rust-call" fn call_mut(&mut self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_mut(&mut self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -57,7 +57,7 @@ impl<'a, I> FnMut<(&'a I,)> for Bool {
 
 #[cfg(feature = "unstable-filter-as-fn")]
 impl<'a, I> Fn<(&'a I,)> for Bool {
-    extern "rust-call" fn call(&self, (_,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call(&self, (_,): (&I,)) -> Self::Output
     {
         self.b
     }

--- a/src/ops/not.rs
+++ b/src/ops/not.rs
@@ -19,10 +19,51 @@ impl<T> Not<T> {
 
 }
 
+#[cfg(not(feature = "unstable-filter-as-fn"))]
 impl<I, T: Filter<I>> Filter<I> for Not<T> {
 
     fn filter(&self, e: &I) -> bool {
         !self.a.filter(e)
     }
 
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, T, I> FnOnce<(&'a I,)> for Not<T>
+    where T: Filter<I>,
+{
+    type Output = bool;
+    extern "rust-call" fn call_once(self, (arg,): (&'a I,)) -> Self::Output
+    {
+        (self)(arg)
+    }
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, T, I> FnMut<(&'a I,)> for Not<T>
+    where T: Filter<I>,
+{
+    extern "rust-call" fn call_mut(&mut self, (arg,): (&'a I,)) -> Self::Output
+    {
+        (self)(arg)
+    }
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, T, I> Fn<(&'a I,)> for Not<T>
+    where T: Filter<I>,
+{
+    extern "rust-call" fn call(&self, (arg,): (&'a I,)) -> Self::Output
+    {
+        !self.a.filter(arg)
+    }
+}
+
+#[cfg(feature="unstable-filter-as-fn")]
+#[test]
+fn fn_not() {
+    let not = Not::new(|&x: &usize| x > 3);
+    for i in 0..10 {
+        assert_eq!(not.filter(&i), not(&i))
+    }
 }

--- a/src/ops/not.rs
+++ b/src/ops/not.rs
@@ -33,7 +33,7 @@ impl<'a, T, I> FnOnce<(&'a I,)> for Not<T>
     where T: Filter<I>,
 {
     type Output = bool;
-    extern "rust-call" fn call_once(self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_once(self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -43,7 +43,7 @@ impl<'a, T, I> FnOnce<(&'a I,)> for Not<T>
 impl<'a, T, I> FnMut<(&'a I,)> for Not<T>
     where T: Filter<I>,
 {
-    extern "rust-call" fn call_mut(&mut self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_mut(&mut self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -53,7 +53,7 @@ impl<'a, T, I> FnMut<(&'a I,)> for Not<T>
 impl<'a, T, I> Fn<(&'a I,)> for Not<T>
     where T: Filter<I>,
 {
-    extern "rust-call" fn call(&self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call(&self, (arg,): (&I,)) -> Self::Output
     {
         !self.a.filter(arg)
     }

--- a/src/ops/or.rs
+++ b/src/ops/or.rs
@@ -35,7 +35,7 @@ impl<'a, T, U, I> FnOnce<(&'a I,)> for Or<T, U>
           U: Filter<I>,
 {
     type Output = bool;
-    extern "rust-call" fn call_once(self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_once(self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -46,7 +46,7 @@ impl<'a, T, U, I> FnMut<(&'a I,)> for Or<T, U>
     where T: Filter<I>,
           U: Filter<I>,
 {
-    extern "rust-call" fn call_mut(&mut self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_mut(&mut self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -57,7 +57,7 @@ impl<'a, T, U, I> Fn<(&'a I,)> for Or<T, U>
     where T: Filter<I>,
           U: Filter<I>,
 {
-    extern "rust-call" fn call(&self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call(&self, (arg,): (&I,)) -> Self::Output
     {
         self.a.filter(arg) || self.b.filter(arg)
     }

--- a/src/ops/xor.rs
+++ b/src/ops/xor.rs
@@ -20,13 +20,54 @@ impl<T, U> XOr<T, U> {
 
 }
 
+#[cfg(not(feature = "unstable-filter-as-fn"))]
 impl<I, T: Filter<I>, U: Filter<I>> Filter<I> for XOr<T, U> {
 
     fn filter(&self, e: &I) -> bool {
-        let a = self.a.filter(e);
-        let b = self.b.filter(e);
-
-        (a && !b) || (!a && b)
+        self.a.filter(e) ^ self.b.filter(e)
     }
 
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, T, U, I> FnOnce<(&'a I,)> for XOr<T, U>
+    where T: Filter<I>,
+          U: Filter<I>,
+{
+    type Output = bool;
+    extern "rust-call" fn call_once(self, (arg,): (&'a I,)) -> Self::Output
+    {
+        (self)(arg)
+    }
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, T, U, I> FnMut<(&'a I,)> for XOr<T, U>
+    where T: Filter<I>,
+          U: Filter<I>,
+{
+    extern "rust-call" fn call_mut(&mut self, (arg,): (&'a I,)) -> Self::Output
+    {
+        (self)(arg)
+    }
+}
+
+#[cfg(feature = "unstable-filter-as-fn")]
+impl<'a, T, U, I> Fn<(&'a I,)> for XOr<T, U>
+    where T: Filter<I>,
+          U: Filter<I>,
+{
+    extern "rust-call" fn call(&self, (arg,): (&'a I,)) -> Self::Output
+    {
+        self.a.filter(arg) ^ self.b.filter(arg)
+    }
+}
+
+#[cfg(feature="unstable-filter-as-fn")]
+#[test]
+fn fn_xor() {
+    let xor = XOr::new(|&x: &usize| x > 3, |&x: &usize| x < 7);
+    for i in 0..10 {
+        assert_eq!(xor.filter(&i), xor(&i))
+    }
 }

--- a/src/ops/xor.rs
+++ b/src/ops/xor.rs
@@ -35,7 +35,7 @@ impl<'a, T, U, I> FnOnce<(&'a I,)> for XOr<T, U>
           U: Filter<I>,
 {
     type Output = bool;
-    extern "rust-call" fn call_once(self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_once(self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -46,7 +46,7 @@ impl<'a, T, U, I> FnMut<(&'a I,)> for XOr<T, U>
     where T: Filter<I>,
           U: Filter<I>,
 {
-    extern "rust-call" fn call_mut(&mut self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call_mut(&mut self, (arg,): (&I,)) -> Self::Output
     {
         (self)(arg)
     }
@@ -57,7 +57,7 @@ impl<'a, T, U, I> Fn<(&'a I,)> for XOr<T, U>
     where T: Filter<I>,
           U: Filter<I>,
 {
-    extern "rust-call" fn call(&self, (arg,): (&'a I,)) -> Self::Output
+    extern "rust-call" fn call(&self, (arg,): (&I,)) -> Self::Output
     {
         self.a.filter(arg) ^ self.b.filter(arg)
     }


### PR DESCRIPTION
feature-gated as functionality not yet available on stable
Also used built-in xor-function for implementation and changed your own to match (was there a reason for doing equivalent checks with `&&` and `||` ?). Either way, both filters are invoked once.

I also noticed that you named your xor struct `XOr`. The std library uses `Xor` (see [std library docs](https://doc.rust-lang.org/std/ops/trait.BitXor.html)).
I propose matching the spelling (but didn't do it in this PR)

This closes #5, at least the part that is actually possible as far as I can see.