### PR TITLE
Minify the XOr implementation

### DIFF
--- a/src/ops/xor.rs
+++ b/src/ops/xor.rs
@@ -23,10 +23,7 @@ impl<T, U> XOr<T, U> {
 impl<I, T: Filter<I>, U: Filter<I>> Filter<I> for XOr<T, U> {
 
     fn filter(&self, e: &I) -> bool {
-        let a = self.a.filter(e);
-        let b = self.b.filter(e);
-
-        (a && !b) || (!a && b)
+        self.a.filter(e) ^ self.b.filter(e)
     }
 
 }


### PR DESCRIPTION
Minify the xor implementation.

I thought there wasn't a logical xor operator in rust, but as said in #6 there is one.