### PR TITLE
Add a top level export

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -261,7 +261,7 @@ pub trait Filter<N> {
 
 #[cfg(test)]
 mod test {
-    use filter::Filter;
+    use Filter;
     use ops::and::And;
     use ops::bool::Bool;
 
@@ -389,7 +389,7 @@ mod test {
 #[cfg(test)]
 #[cfg(feature = "unstable-filter-as-fn")]
 mod test_unstable {
-    use filter::Filter;
+    use Filter;
     use ops::bool::Bool;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,3 +79,4 @@ pub mod filter;
 pub mod impl_traits;
 pub mod ops;
 
+pub use filter::Filter;


### PR DESCRIPTION
This way people can just do `use filters::Filter;`

This closes #2 
