### PR TITLE
AndVec

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -404,6 +404,38 @@ mod test {
 
         assert_eq!(r, vec![6, 7, 8, 9, 10, 11, 12, 13, 14]);
     }
+
+    #[test]
+    fn filter_vec_and() {
+        let f1 = |&a: &usize| { a == 1 };
+        let f2 = |&a: &usize| { a == 1 };
+        let f3 = |&a: &usize| { a == 1 };
+        let f4 = |&a: &usize| { a == 1 };
+        let f5 = |&a: &usize| { a == 1 };
+        let f6 = |&a: &usize| { a == 1 };
+        let f7 = |&a: &usize| { a == 1 };
+        let f8 = |&a: &usize| { a == 1 };
+
+        let f = (|&a: &usize| { a > 0 })
+            .and(|&a: &usize| { a < 2 })
+            .and(f1)
+            .and_vec()
+            .push(f2)
+            .push(f3)
+            .push(f4)
+            .push(f5)
+            .push(f6)
+            .push(f7)
+            .push(f8);
+
+        assert_eq!(f.filter(&0), false);
+        assert_eq!(f.filter(&1), true);
+        assert_eq!(f.filter(&2), false);
+        assert_eq!(f.filter(&3), false);
+        assert_eq!(f.filter(&4), false);
+        assert_eq!(f.filter(&5), false);
+    }
+
 }
 
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -7,11 +7,11 @@
 //! The filter implementation
 //!
 
-pub use ops::and::And;
+pub use ops::and::{And, AndVec};
 pub use ops::bool::Bool;
 pub use ops::not::Not;
-pub use ops::xor::XOr;
-pub use ops::or::Or;
+pub use ops::xor::{XOr, XOrVec};
+pub use ops::or::{Or, OrVec};
 
 /// Trait for converting something into a Filter
 pub trait IntoFilter<N> {
@@ -254,6 +254,27 @@ pub trait Filter<N> {
         where Self: Sized,
     {
         Not::new(And::new(self, other))
+    }
+
+    /// Build an AndVec filter object, using `self` as first element of the vec.
+    fn and_vec(self) -> AndVec<Self>
+        where Self: Sized,
+    {
+        AndVec::new(vec![Box::new(self)])
+    }
+
+    /// Build an OrVec filter object, using `self` as first element of the vec.
+    fn or_vec(self) -> OrVec<Self>
+        where Self: Sized,
+    {
+        OrVec::new(vec![Box::new(self)])
+    }
+
+    /// Build an XOrVec filter object, using `self` as first element of the vec.
+    fn xor_vec(self) -> XOrVec<Self>
+        where Self: Sized,
+    {
+        XOrVec::new(vec![Box::new(self)])
     }
 
 }

--- a/src/ops/and.rs
+++ b/src/ops/and.rs
@@ -54,24 +54,6 @@ impl<I> AndVec<I> {
         self
     }
 
-    // convenient function to build a AndVec from a Filter using Filter::and_vec()
-    //
-    // Using this function, one can:
-    //
-    // ```ignore
-    //  some_filter.and_vec()
-    //      .push(another)
-    //      .push(filter)
-    //      .push(which)
-    //      .push(filters)
-    //      .or(something_else)
-    //      .filter(&element)
-    //  ```
-    pub fn push(&mut self, i: I) -> &mut Self {
-        self.0.push(Box::new(i));
-        self
-    }
-
 }
 
 impl<I, F: Filter<I>> Filter<I> for AndVec<Box<F>> {

--- a/src/ops/and.rs
+++ b/src/ops/and.rs
@@ -27,3 +27,40 @@ impl<T, U> And<T, U> {
 }
 
 impl_operators!(And, self e { self.a.filter(e) && self.b.filter(e) }, T, U);
+
+pub struct AndVec<I>(Vec<Box<I>>);
+
+impl<I> AndVec<I> {
+
+    pub fn new(i: Vec<Box<I>>) -> AndVec<I> {
+        AndVec(i)
+    }
+
+    // convenient function to build a AndVec from a Filter using Filter::and_vec()
+    //
+    // Using this function, one can:
+    //
+    // ```ignore
+    //  some_filter.and_vec()
+    //      .push(another)
+    //      .push(filter)
+    //      .push(which)
+    //      .push(filters)
+    //      .or(something_else)
+    //      .filter(&element)
+    //  ```
+    pub fn push(&mut self, i: I) -> &mut Self {
+        self.0.push(Box::new(i));
+        self
+    }
+
+}
+
+impl<I, F: Filter<I>> Filter<I> for AndVec<Box<F>> {
+
+    fn filter(&self, e: &I) -> bool {
+        self.0.iter().all(|f| f.filter(e))
+    }
+
+}
+

--- a/src/ops/and.rs
+++ b/src/ops/and.rs
@@ -54,6 +54,24 @@ impl<I> AndVec<I> {
         self
     }
 
+    // convenient function to build a AndVec from a Filter using Filter::and_vec()
+    //
+    // Using this function, one can:
+    //
+    // ```ignore
+    //  some_filter.and_vec()
+    //      .push(another)
+    //      .push(filter)
+    //      .push(which)
+    //      .push(filters)
+    //      .or(something_else)
+    //      .filter(&element)
+    //  ```
+    pub fn push(&mut self, i: I) -> &mut Self {
+        self.0.push(Box::new(i));
+        self
+    }
+
 }
 
 impl<I, F: Filter<I>> Filter<I> for AndVec<Box<F>> {

--- a/src/ops/or.rs
+++ b/src/ops/or.rs
@@ -27,3 +27,40 @@ impl<T, U> Or<T, U> {
 }
 
 impl_operators!(Or, self e { self.a.filter(e) || self.b.filter(e) }, T, U);
+
+pub struct OrVec<I>(Vec<Box<I>>);
+
+impl<I> OrVec<I> {
+
+    pub fn new(i: Vec<Box<I>>) -> OrVec<I> {
+        OrVec(i)
+    }
+
+    // convenient function to build a OrVec from a Filter using Filter::or_vec()
+    //
+    // Using this function, one can:
+    //
+    // ```ignore
+    //  some_filter.or_vec()
+    //      .push(another)
+    //      .push(filter)
+    //      .push(which)
+    //      .push(filters)
+    //      .and(something_else)
+    //      .filter(&element)
+    //  ```
+    pub fn push(&mut self, i: I) -> &mut Self {
+        self.0.push(Box::new(i));
+        self
+    }
+
+}
+
+impl<I, F: Filter<I>> Filter<I> for OrVec<Box<F>> {
+
+    fn filter(&self, e: &I) -> bool {
+        self.0.iter().any(|f| f.filter(e))
+    }
+
+}
+

--- a/src/ops/xor.rs
+++ b/src/ops/xor.rs
@@ -27,3 +27,50 @@ impl<T, U> XOr<T, U> {
 }
 
 impl_operators!(XOr, self e { self.a.filter(e) ^ self.b.filter(e) }, T, U);
+
+pub struct XOrVec<I>(Vec<Box<I>>);
+
+impl<I> XOrVec<I> {
+
+    pub fn new(i: Vec<Box<I>>) -> XOrVec<I> {
+        XOrVec(i)
+    }
+
+    // convenient function to build a XOrVec from a Filter using Filter::xor_vec()
+    //
+    // Using this function, one can:
+    //
+    // ```ignore
+    //  some_filter.xor_vec()
+    //      .push(another)
+    //      .push(filter)
+    //      .push(which)
+    //      .push(filters)
+    //      .or(something_else)
+    //      .filter(&element)
+    //  ```
+    pub fn push(&mut self, i: I) -> &mut Self {
+        self.0.push(Box::new(i));
+        self
+    }
+
+}
+
+impl<I, F: Filter<I>> Filter<I> for XOrVec<Box<F>> {
+
+    fn filter(&self, e: &I) -> bool {
+        let mut b = false;
+        for f in self.0.iter() {
+            if f.filter(e) {
+                if b { // if there is already a filter which returned true, xor yields false
+                    return false;
+                } else { // if there is no filter yet that yielded true, we can toggle the flag
+                    b = true;
+                }
+            }
+        }
+        return b
+    }
+
+}
+


### PR DESCRIPTION
This is an experiment for a `AndVec` type which can contain up to `N` filters and execute them using an `all()` iterator.

The (logical) next step would be to include multithreading in the filter iteration.
