### PR TITLE
Add filter map functions

### DIFF
--- a/src/failable/ops/map.rs
+++ b/src/failable/ops/map.rs
@@ -1,0 +1,58 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+//! Map implementation.
+//!
+//! Will be automatically included when incluing `filter::Filter`, so importing this module
+//! shouldn't be necessary.
+//!
+use std::marker::PhantomData;
+use std::borrow::Borrow;
+use std::error::Error;
+
+use failable::filter::FailableFilter;
+
+#[must_use = "filters are lazy and do nothing unless consumed"]
+#[derive(Clone)]
+pub struct FailableMapInput<F, M, FT, B>(F, M, PhantomData<FT>, PhantomData<B>);
+
+impl<F, M, FT, B> FailableMapInput<F, M, FT, B> {
+    pub fn new(a: F, m: M) -> FailableMapInput<F, M, FT, B> {
+        FailableMapInput(a, m, PhantomData, PhantomData)
+    }
+}
+
+impl<FT, E, F, T, B, M> FailableFilter<T, E> for FailableMapInput<F, M, FT, B>
+    where E: Error,
+          F: FailableFilter<FT, E>,
+          B: Borrow<FT> + Sized,
+          M: Fn(&T) -> B
+{
+    fn filter(&self, e: &T) -> Result<bool, E> {
+        self.0.filter(self.1(e).borrow())
+    }
+}
+
+#[must_use = "filters are lazy and do nothing unless consumed"]
+#[derive(Clone)]
+pub struct FailableMapErr<F, M, FE, E>(F, M, PhantomData<FE>, PhantomData<E>);
+
+impl<F, M, FE, E> FailableMapErr<F, M, FE, E> {
+    pub fn new(a: F, m: M) -> FailableMapErr<F, M, FE, E> {
+        FailableMapErr(a, m, PhantomData, PhantomData)
+    }
+}
+
+impl<FE, E, F, T, M> FailableFilter<T, E> for FailableMapErr<F, M, FE, E>
+    where E: Error,
+          FE: Error,
+          F: FailableFilter<T, FE>,
+          M: Fn(FE) -> E
+{
+    fn filter(&self, e: &T) -> Result<bool, E> {
+        self.0.filter(e).map_err(&self.1)
+    }
+}

--- a/src/failable/ops/mod.rs
+++ b/src/failable/ops/mod.rs
@@ -9,3 +9,4 @@ pub mod bool;
 pub mod not;
 pub mod xor;
 pub mod or;
+pub mod map;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -6,12 +6,14 @@
 
 //! The filter implementation
 //!
+use std::borrow::Borrow;
 
 pub use ops::and::And;
 pub use ops::bool::Bool;
 pub use ops::not::Not;
 pub use ops::xor::XOr;
 pub use ops::or::Or;
+pub use ops::map::MapInput;
 
 /// Trait for converting something into a Filter
 pub trait IntoFilter<N> {
@@ -36,7 +38,7 @@ impl<I, T: Fn(&I) -> bool> Filter<I> for T {
     }
 }
 
-/// The filter trai
+/// The filter trait
 pub trait Filter<N> {
 
     /// The function which is used to filter something
@@ -256,6 +258,29 @@ pub trait Filter<N> {
         Not::new(And::new(self, other))
     }
 
+    /// Helper to transform the input of a filter
+    ///
+    /// ```
+    /// use filters::filter::Filter;
+    ///
+    /// let a = (|&a: &usize| { a > 1 });
+    /// let b = (|&a: &i64| { a < 7 });
+    /// let b = b.map_input(|&x: &usize| { x as i64 });
+    /// let c = a.and(b);
+    ///
+    /// assert!(!c.filter(&1));
+    /// assert!(c.filter(&3));
+    /// assert!(c.filter(&4));
+    /// assert!(c.filter(&6));
+    /// assert!(!c.filter(&9));
+    /// ```
+    fn map_input<O, B, T, M>(self, map: M) -> MapInput<Self, M, O, B>
+        where Self: Sized,
+              M: Fn(&T) -> N,
+              B: Borrow<O> + Sized
+    {
+        MapInput::new(self, map)
+    }
 }
 
 

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -1,0 +1,35 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+//! Map implementation.
+//!
+//! Will be automatically included when incluing `filter::Filter`, so importing this module
+//! shouldn't be necessary.
+//!
+use std::marker::PhantomData;
+use std::borrow::Borrow;
+
+use filter::Filter;
+
+#[must_use = "filters are lazy and do nothing unless consumed"]
+#[derive(Clone)]
+pub struct MapInput<F, M, FT, B>(F, M, PhantomData<FT>, PhantomData<B>);
+
+impl<F, M, FT, B> MapInput<F, M, FT, B> {
+    pub fn new(a: F, m: M) -> MapInput<F, M, FT, B> {
+        MapInput(a, m, PhantomData, PhantomData)
+    }
+}
+
+impl<FT, F, T, B, M> Filter<T> for MapInput<F, M, FT, B>
+    where F: Filter<FT>,
+          B: Borrow<FT> + Sized,
+          M: Fn(&T) -> B
+{
+    fn filter(&self, e: &T) -> bool {
+        self.0.filter(self.1(e).borrow())
+    }
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -9,3 +9,4 @@ pub mod bool;
 pub mod not;
 pub mod or;
 pub mod xor;
+pub mod map;


### PR DESCRIPTION
Merges into `failable-filter` (#20)

Just has a couple of doctests right now, but since its primarily type based, it should be OK. You could consider adding more tests though.