### PR TITLE
Add into_failable and as_failable methods

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -14,6 +14,7 @@ pub use ops::not::Not;
 pub use ops::xor::XOr;
 pub use ops::or::Or;
 pub use ops::map::MapInput;
+pub use ops::failable::{IntoFailable, AsFailable};
 
 /// Trait for converting something into a Filter
 pub trait IntoFilter<N> {
@@ -280,6 +281,45 @@ pub trait Filter<N> {
               B: Borrow<O> + Sized
     {
         MapInput::new(self, map)
+    }
+
+    /// Helper to transform a filter into a FailableFilter
+    ///
+    /// ```
+    /// use filters::filter::Filter;
+    /// use filters::failable::filter::FailableFilter;
+    ///
+    /// let a = (|&a: &usize| { a > 5 });
+    /// let a = a.into_failable();
+    /// 
+    /// assert_eq!(a.filter(&3), Ok(false));
+    /// assert_eq!(a.filter(&5), Ok(false));
+    /// assert_eq!(a.filter(&7), Ok(true));
+    /// assert_eq!(a.filter(&9), Ok(true));
+    /// ```
+    fn into_failable(self) -> IntoFailable<Self, ()>
+        where Self: Sized
+    {
+        IntoFailable::new(self)
+    }
+
+    /// Helper to borrow a filter as a FailbleFilter
+    ///
+    /// ```
+    /// use filters::filter::Filter;
+    /// use filters::failable::filter::FailableFilter;
+    ///
+    /// let a = (|&a: &usize| { a > 5 });
+    /// let b = a.as_failable();
+    /// 
+    /// assert_eq!(a.filter(&3), false);
+    /// assert_eq!(b.filter(&3), Ok(false));
+    /// assert_eq!(a.filter(&7), true);
+    /// assert_eq!(b.filter(&7), Ok(true));
+    fn as_failable<'a>(&'a self) -> AsFailable<'a, Self, ()>
+        where Self: 'a
+    {
+        AsFailable::new(self)
     }
 }
 

--- a/src/ops/failable.rs
+++ b/src/ops/failable.rs
@@ -1,0 +1,51 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+//! Filter -> FailableFilter implementations
+//!
+//! Will be automatically included when incluing `filter::Filter`, so importing this module
+//! shouldn't be necessary.
+//!
+use std::marker::PhantomData;
+
+use filter::Filter;
+use failable::filter::FailableFilter;
+
+#[must_use = "filters are lazy and do nothing unless consumed"]
+#[derive(Clone)]
+pub struct IntoFailable<F, E>(F, PhantomData<E>);
+
+impl<F, E> IntoFailable<F, E> {
+    pub fn new(a: F) -> IntoFailable<F, E> {
+        IntoFailable(a, PhantomData)
+    }
+}
+
+impl<F, N, E> FailableFilter<N, E> for IntoFailable<F, E>
+    where F: Filter<N>,
+{
+    fn filter(&self, e: &N) -> Result<bool, E> {
+        Ok(self.0.filter(e))
+    }
+}
+
+#[must_use = "filters are lazy and do nothing unless consumed"]
+#[derive(Clone)]
+pub struct AsFailable<'a, F: 'a + ?Sized, E>(&'a F, PhantomData<E>);
+
+impl<'a, F: 'a + ?Sized, E> AsFailable<'a, F, E> {
+    pub fn new(a: &'a F) -> AsFailable<F, E> {
+        AsFailable(a, PhantomData)
+    }
+}
+
+impl<'a, F, N, E> FailableFilter<N, E> for AsFailable<'a, F, E>
+    where F: Filter<N> + 'a + ?Sized,
+{
+    fn filter(&self, e: &N) -> Result<bool, E> {
+        Ok(self.0.filter(e))
+    }
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -10,3 +10,4 @@ pub mod not;
 pub mod or;
 pub mod xor;
 pub mod map;
+pub mod failable;


### PR DESCRIPTION
Once again, a PR into #21.

The IntoFailable and AsFailable types are created to allow for any error type, but their respective functions on Filter always use `()` as the error type. I think that's about the right level of flexibility, but we could consider allowing for other error types or adding separate functions that allow for other error types.