### PR TITLE
Make error type associated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * A macro was added to quickly create `Filter` implementations
 * An extension for iterators was added to filter the iterator with the filter
   object. This removes the need to write a closure.
+* `FailableFilter` uses an associated type for the error output type now.
 
 # 0.2.0
 

--- a/src/failable/ops/and.rs
+++ b/src/failable/ops/and.rs
@@ -24,11 +24,13 @@ impl<T, U> FailableAnd<T, U> {
 
 }
 
-impl<N, E, T, U> FailableFilter<N, E> for FailableAnd<T, U>
-    where T: FailableFilter<N, E>,
-          U: FailableFilter<N, E>
+impl<N, T, U, E> FailableFilter<N> for FailableAnd<T, U>
+    where T: FailableFilter<N, Error = E>,
+          U: FailableFilter<N, Error = E>
 {
-    fn filter(&self, e: &N) -> Result<bool, E> {
+    type Error = E;
+
+    fn filter(&self, e: &N) -> Result<bool, Self::Error> {
         Ok(try!(self.0.filter(e)) && try!(self.1.filter(e)))
     }
 }

--- a/src/failable/ops/bool.rs
+++ b/src/failable/ops/bool.rs
@@ -32,8 +32,10 @@ impl From<bool> for FailableBool {
 
 }
 
-impl<N, E> FailableFilter<N, E> for FailableBool {
-    fn filter(&self, _: &N) -> Result<bool, E> {
+impl<N> FailableFilter<N> for FailableBool {
+    type Error = ();
+
+    fn filter(&self, _: &N) -> Result<bool, Self::Error> {
         Ok(self.0)
     }
 }

--- a/src/failable/ops/not.rs
+++ b/src/failable/ops/not.rs
@@ -24,10 +24,12 @@ impl<T> FailableNot<T> {
 
 }
 
-impl<N, E, T> FailableFilter<N, E> for FailableNot<T>
-    where T: FailableFilter<N, E>
+impl<N, T> FailableFilter<N> for FailableNot<T>
+    where T: FailableFilter<N>
 {
-    fn filter(&self, e: &N) -> Result<bool, E> {
+    type Error = T::Error;
+
+    fn filter(&self, e: &N) -> Result<bool, Self::Error> {
         self.0.filter(e).map(|b| !b)
     }
 }

--- a/src/failable/ops/or.rs
+++ b/src/failable/ops/or.rs
@@ -24,11 +24,13 @@ impl<T, U> FailableOr<T, U> {
 
 }
 
-impl<N, E, T, U> FailableFilter<N, E> for FailableOr<T, U>
-    where T: FailableFilter<N, E>,
-          U: FailableFilter<N, E>
+impl<N, T, U, E> FailableFilter<N> for FailableOr<T, U>
+    where T: FailableFilter<N, Error = E>,
+          U: FailableFilter<N, Error = E>
 {
-    fn filter(&self, e: &N) -> Result<bool, E> {
+    type Error = E;
+
+    fn filter(&self, e: &N) -> Result<bool, Self::Error> {
         Ok(try!(self.0.filter(e)) || try!(self.1.filter(e)))
     }
 }

--- a/src/failable/ops/xor.rs
+++ b/src/failable/ops/xor.rs
@@ -24,11 +24,13 @@ impl<T, U> FailableXOr<T, U> {
 
 }
 
-impl<N, E, T, U> FailableFilter<N, E> for FailableXOr<T, U>
-    where T: FailableFilter<N, E>,
-          U: FailableFilter<N, E>
+impl<N, T, U, E> FailableFilter<N> for FailableXOr<T, U>
+    where T: FailableFilter<N, Error = E>,
+          U: FailableFilter<N, Error = E>
 {
-    fn filter(&self, e: &N) -> Result<bool, E> {
+    type Error = E;
+
+    fn filter(&self, e: &N) -> Result<bool, Self::Error> {
         Ok(try!(self.0.filter(e)) ^ try!(self.1.filter(e)))
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -297,7 +297,7 @@ pub trait Filter<N> {
     /// assert_eq!(a.filter(&7), Ok(true));
     /// assert_eq!(a.filter(&9), Ok(true));
     /// ```
-    fn into_failable(self) -> IntoFailable<Self, ()>
+    fn into_failable(self) -> IntoFailable<Self>
         where Self: Sized
     {
         IntoFailable::new(self)
@@ -316,7 +316,7 @@ pub trait Filter<N> {
     /// assert_eq!(b.filter(&3), Ok(false));
     /// assert_eq!(a.filter(&7), true);
     /// assert_eq!(b.filter(&7), Ok(true));
-    fn as_failable<'a>(&'a self) -> AsFailable<'a, Self, ()>
+    fn as_failable<'a>(&'a self) -> AsFailable<'a, Self>
         where Self: 'a
     {
         AsFailable::new(self)

--- a/src/ops/failable.rs
+++ b/src/ops/failable.rs
@@ -9,43 +9,46 @@
 //! Will be automatically included when including `filter::Filter`, so importing this module
 //! shouldn't be necessary.
 //!
-use std::marker::PhantomData;
 
 use filter::Filter;
 use failable::filter::FailableFilter;
 
 #[must_use = "filters are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct IntoFailable<F, E>(F, PhantomData<E>);
+pub struct IntoFailable<F>(F);
 
-impl<F, E> IntoFailable<F, E> {
-    pub fn new(a: F) -> IntoFailable<F, E> {
-        IntoFailable(a, PhantomData)
+impl<F> IntoFailable<F> {
+    pub fn new(a: F) -> IntoFailable<F> {
+        IntoFailable(a)
     }
 }
 
-impl<F, N, E> FailableFilter<N, E> for IntoFailable<F, E>
+impl<F, N> FailableFilter<N> for IntoFailable<F>
     where F: Filter<N>,
 {
-    fn filter(&self, e: &N) -> Result<bool, E> {
+    type Error = ();
+
+    fn filter(&self, e: &N) -> Result<bool, Self::Error> {
         Ok(self.0.filter(e))
     }
 }
 
 #[must_use = "filters are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct AsFailable<'a, F: 'a + ?Sized, E>(&'a F, PhantomData<E>);
+pub struct AsFailable<'a, F: 'a + ?Sized>(&'a F);
 
-impl<'a, F: 'a + ?Sized, E> AsFailable<'a, F, E> {
-    pub fn new(a: &'a F) -> AsFailable<F, E> {
-        AsFailable(a, PhantomData)
+impl<'a, F: 'a + ?Sized> AsFailable<'a, F> {
+    pub fn new(a: &'a F) -> AsFailable<F> {
+        AsFailable(a)
     }
 }
 
-impl<'a, F, N, E> FailableFilter<N, E> for AsFailable<'a, F, E>
+impl<'a, F, N> FailableFilter<N> for AsFailable<'a, F>
     where F: Filter<N> + 'a + ?Sized,
 {
-    fn filter(&self, e: &N) -> Result<bool, E> {
+    type Error = ();
+
+    fn filter(&self, e: &N) -> Result<bool, Self::Error> {
         Ok(self.0.filter(e))
     }
 }


### PR DESCRIPTION
The problem with the FailingFilter was, that the error type was not an
associated type but a generic type parameter.

This patch fixes this.